### PR TITLE
Add `install_requires` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setuptools.setup(
             'jassign = jassign.__main__:main'
         ]
     },
+    install_requires=[
+        "pyyaml", "okpy", "nbformat", "ipython", "nbconvert", "tqdm", "setuptools"
+    ],
 )


### PR DESCRIPTION
So these dependencies can be installed with just `pip install jassign`