### PR TITLE
Add arg option to "open" all test cases for autograder view

### DIFF
--- a/jassign/jassign.py
+++ b/jassign/jassign.py
@@ -16,13 +16,16 @@ def parse_args():
     parser.add_argument("--no-submit-cell", help="Don't output submit cell at end of notebook",
     	dest="no_submit_cell", const=True, default=False, action="store_const"
     	)
+    parser.add_argument("--open-ag-tests", help="Unlock and unhide all test cases for autograder view",
+        dest="open_ag_tests", const=True, default=False, action="store_const"
+        )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
     gen_views(pathlib.Path(args.master), pathlib.Path(args.result),
-              args.endpoint, args.no_submit_cell)
+              args.endpoint, args.no_submit_cell, args.open_ag_tests)
 
 if __name__ == "__main__":
     main()

--- a/jassign/to_ok.py
+++ b/jassign/to_ok.py
@@ -382,7 +382,7 @@ def lock(cell):
     m["deletable"] = False
 
 
-def gen_views(master_nb, result_dir, endpoint, no_submit_cell):
+def gen_views(master_nb, result_dir, endpoint, no_submit_cell, open_ag_tests):
     """Generate student and autograder views.
 
     master_nb -- Dict of master notebook JSON
@@ -395,9 +395,13 @@ def gen_views(master_nb, result_dir, endpoint, no_submit_cell):
     ok_nb_path = convert_to_ok(master_nb, autograder_dir, endpoint, no_submit_cell)
     
     shutil.copytree(autograder_dir, student_dir)
-    # In the autograder view, use the test files in the open_tests/ directory.
-    shutil.rmtree(autograder_dir / "tests")
-    shutil.move(autograder_dir / "open_tests", autograder_dir / "tests")
+    if open_ag_tests:
+        # In the autograder view, use the test files in the open_tests/ directory.
+        shutil.rmtree(autograder_dir / "tests")
+        shutil.move(autograder_dir / "open_tests", autograder_dir / "tests")
+    else:
+        # In the autograder view, use the test files in the tests/ directory.
+        shutil.rmtree(autograder_dir / "open_tests")
     # In the student view, use the test files in the tests/ directory.
     shutil.rmtree(student_dir / "open_tests")
     


### PR DESCRIPTION
The Data 8 autograder (run on OK) currently requires all test cases to have `hidden: False` and `locked: False`. Currently, the `autograder/` view keeps the hidden cases as `hidden: True`, so we add an optional argument `--open-ag-tests` that will go in and open every test case.